### PR TITLE
Feat: prefill submission form with prev submission

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -8,6 +8,11 @@ class SubmissionsController < ApplicationController
       redirect_to(questionnaire_path(@questionnaire), alert: "current questionnaire doesn't have any questions yet") and return
     end
 
+    @old_submission = nil
+    if prefill_with_prev_submission_params
+      @old_submission = @questionnaire.submissions.last
+    end
+
     @submission = @questionnaire.submissions.new
     @questionnaire.questions.kept.each do |question|
       @submission.submission_values.new(question: question)
@@ -50,6 +55,10 @@ class SubmissionsController < ApplicationController
   end
 
   private
+
+  def prefill_with_prev_submission_params
+    ActiveRecord::Type::Boolean.new.cast(params[:prefill_with_prev_submission])
+  end
 
   def submission_params
     params.require(:submission)

--- a/app/views/submissions/new.html.erb
+++ b/app/views/submissions/new.html.erb
@@ -23,15 +23,19 @@
             <% end %>
           <% end %>
           <% if question.date? %>
-            <%= submission_values_f.date_field :value, required: !question.is_emptyable? %>
+            <%= submission_values_f.date_field :value, required: !question.is_emptyable?, value: @old_submission&.submission_values&.find_by(question: question)&.value %>
           <% else %>
-            <%= submission_values_f.text_field :value, required: !question.is_emptyable?, pattern: question.valid_pattern %>
+            <%= submission_values_f.text_field :value, required: !question.is_emptyable?, pattern: question.valid_pattern, value: @old_submission&.submission_values&.find_by(question: question)&.value %>
           <% end %>
         </fieldset>
     <% end %>
 
     <div class="actions">
       <%= f.submit "save submission", class: "button" %>
+      <%= link_to new_questionnaire_submission_path(@questionnaire, prefill_with_prev_submission: true), class: "button" do %>
+        <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="currentColor"><path d="M360-280q-33 0-56.5-23.5T280-360v-400q0-33 23.5-56.5T360-840h400q33 0 56.5 23.5T840-760v400q0 33-23.5 56.5T760-280H360Zm0-80h400v-400H360v400ZM200-200v80q-33 0-56.5-23.5T120-200h80Zm-80-80v-80h80v80h-80Zm0-160v-80h80v80h-80Zm0-160v-80h80v80h-80Zm160 480v-80h80v80h-80Zm160 0v-80h80v80h-80Zm160 0v-80h80v80h-80Z"/></svg>
+        prefill with previous submission
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/spec/support/features/pages/questionnaire_add_submission_page.rb
+++ b/spec/support/features/pages/questionnaire_add_submission_page.rb
@@ -1,12 +1,12 @@
 class QuestionnaireAddSubmissionPage < SitePrism::Page
-  set_url "/questionnaires{/id}/submissions/new"
+  set_url "/questionnaires{/id}/submissions/new{?query*}"
 
   section :hero, QuestionnaireHeroSection
   element :subnavbar, "#questionnaire-subnavbar"
   section :main_view, "#questionnaire-main-view" do
     sections :question_fields, "fieldset" do
-      element :question_label, "label"
-      element :question_field, "input"
+      element :label, "label"
+      element :input, "input"
     end
     element :submit_btn, "input[type='submit']"
   end


### PR DESCRIPTION
* change some redundant method on `spec/support/features/pages/questionnaire_add_submission_page.rb`
* add spec
* implement prefill link that add query parameters `prefill_with_prev_submission=<bool>` to url which signalling `submissions_controller#new` to query previous submission and attach it to each input's value